### PR TITLE
Added normalization of documents to support multlline completions

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -220,12 +220,12 @@ fn normalize_document_and_cursor_position(
     let content_before_cursor = lines
         .iter()
         .take(cursor_line)
-        .map(|l| *l)
+        .copied()
         .collect::<Vec<&str>>()
         .join(join_char);
 
     let cursor_char = content_before_cursor.len() + cursor_char + 1;
-    let curr_doc = format!("{}\n", &lines.join(&join_char));
+    let curr_doc = format!("{}\n", &lines.join(join_char));
 
     (curr_doc, 0, cursor_char)
 }
@@ -261,7 +261,7 @@ fn get_completion_list(
                     (keyword_select) @select_options
                     "#,
                 )
-                .expect("Could not initialize query")
+                .expect("Could not initialise query")
             });
 
         let matches_iter = cursor.matches(&QUERY_INSTR_ANY, tree.root_node(), curr_doc);
@@ -288,7 +288,7 @@ fn get_completion_list(
         static QUERY_STATEMEMENT_START: once_cell::sync::Lazy<tree_sitter::Query> =
             once_cell::sync::Lazy::new(|| {
                 tree_sitter::Query::new(tree_sitter_surrealql::language(), "(ERROR) @start")
-                    .expect("Could not initialize query")
+                    .expect("Could not initialise query")
             });
 
         for match_ in cursor.matches(&QUERY_STATEMEMENT_START, tree.root_node(), curr_doc) {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -206,6 +206,30 @@ fn initialise_parser() -> tree_sitter::Parser {
     parser
 }
 
+fn normalize_document_and_cursor_position(
+    doc: &str,
+    cursor_line: usize,
+    cursor_char: usize,
+) -> (String, usize, usize) {
+    let lines: Vec<&str> = doc.lines().collect();
+    if lines.len() <= 1 {
+        return (doc.to_string(), cursor_line, cursor_char);
+    }
+    let join_char = " ";
+
+    let content_before_cursor = lines
+        .iter()
+        .take(cursor_line)
+        .map(|l| *l)
+        .collect::<Vec<&str>>()
+        .join(join_char);
+
+    let cursor_char = content_before_cursor.len() + cursor_char + 1;
+    let curr_doc = format!("{}\n", &lines.join(&join_char));
+
+    (curr_doc, 0, cursor_char)
+}
+
 fn get_completion_list(
     curr_doc: &str,
     parser: &mut tree_sitter::Parser,
@@ -218,6 +242,9 @@ fn get_completion_list(
 ) -> Option<Vec<tower_lsp::lsp_types::CompletionItem>> {
     let cursor_line = params.text_document_position.position.line as usize;
     let cursor_char = params.text_document_position.position.character as usize;
+    let (curr_doc, cursor_line, cursor_char) =
+        normalize_document_and_cursor_position(curr_doc, cursor_line, cursor_char);
+    let curr_doc = &curr_doc;
 
     *curr_tree = parser.parse(curr_doc, curr_tree.as_ref());
     if let Some(tree) = curr_tree {
@@ -234,7 +261,7 @@ fn get_completion_list(
                     (keyword_select) @select_options
                     "#,
                 )
-                .expect("Could not initialise query")
+                .expect("Could not initialize query")
             });
 
         let matches_iter = cursor.matches(&QUERY_INSTR_ANY, tree.root_node(), curr_doc);
@@ -261,7 +288,7 @@ fn get_completion_list(
         static QUERY_STATEMEMENT_START: once_cell::sync::Lazy<tree_sitter::Query> =
             once_cell::sync::Lazy::new(|| {
                 tree_sitter::Query::new(tree_sitter_surrealql::language(), "(ERROR) @start")
-                    .expect("Could not initialise query")
+                    .expect("Could not initialize query")
             });
 
         for match_ in cursor.matches(&QUERY_STATEMEMENT_START, tree.root_node(), curr_doc) {
@@ -477,4 +504,42 @@ async fn main() {
     tower_lsp::Server::new(stdin, stdout, socket)
         .serve(service)
         .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::normalize_document_and_cursor_position;
+
+    #[test]
+    fn correctly_normalizes_document() {
+        let doc = r#"
+abc
+def
+hij"#;
+        let cursor_line = 3;
+        let cursor_char = 2;
+
+        let expected = (" abc def hij\n".to_string(), 0, 11);
+        let out = normalize_document_and_cursor_position(doc, cursor_line, cursor_char);
+        assert_eq!(out, expected);
+
+        let doc = r#"abcdef
+hij
+klm"#;
+        let cursor_line = 1;
+        let cursor_char = 2;
+
+        let expected = ("abcdef hij klm\n".to_string(), 0, 9);
+        let out = normalize_document_and_cursor_position(doc, cursor_line, cursor_char);
+        assert_eq!(out, expected);
+        let doc = r#"SELECT * FROM table
+WH
+"#;
+        let cursor_line = 1;
+        let cursor_char = 2;
+
+        let expected = ("SELECT * FROM table WH\n".to_string(), 0, 22);
+        let out = normalize_document_and_cursor_position(doc, cursor_line, cursor_char);
+        assert_eq!(out, expected);
+    }
 }

--- a/examples/test.surql
+++ b/examples/test.surql
@@ -1,2 +1,1 @@
-SELECT * FROM person:cellan 
-;
+SELECT * FROM person:cellan;

--- a/examples/test.surql
+++ b/examples/test.surql
@@ -1,1 +1,2 @@
-SELECT * FROM person:cellan;
+SELECT * FROM person:cellan 
+;


### PR DESCRIPTION
In order to support completions of docs when there are multiple lines, documents are normalized and the cursor position is recomputed to account for the normalization. 

https://github.com/user-attachments/assets/01ca3a0a-2944-434e-b559-caa7cd964dd9

It is not shown in the video, but the way this is implemented allows for an arbitrary amount of newlines without breaking completions. For example, 
```sql
SELECT
*
FROM 
<table>








WH
```
would still return a completion.